### PR TITLE
remove cypress from devDependencies and install in CI, so the app is deployable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ node_js:
 env:
   global:
     - BUILD_TIMEOUT=10000
-install: npm install
+install:
+  - npm install
+  - npm install cypress
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,3 +15,4 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install
+  - npm install cypress

--- a/package.json
+++ b/package.json
@@ -25,8 +25,5 @@
     "svelte": "^1.49.1",
     "svelte-loader": "^2.2.1",
     "uglifyjs-webpack-plugin": "^1.1.2"
-  },
-  "devDependencies": {
-    "cypress": "^1.2.0"
   }
 }


### PR DESCRIPTION
Running `now` failed, because it was trying to install Cypress. This removes it and installs Cypress in CI instead