### PR TITLE
Add TypeScript support for non-component source code

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "style-loader": "^0.19.1",
     "svelte": "^1.50.0",
     "svelte-loader": "^2.3.3",
+    "ts-loader": "^3.2.0",
+    "tslib": "^1.8.1",
+    "typescript": "^2.6.2",
     "uglifyjs-webpack-plugin": "^1.1.5",
     "webpack": "^3.10.0"
   },
-   "engines": {
+  "engines": {
     "node": ">= 8"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "diagnostics": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "noEmitOnError": true,
+        "allowJs": true,
+        "lib": ["es5", "es6", "dom"],
+        "importHelpers": true
+    },
+    "target": "ES5",
+    "include": [
+        "routes",
+        "templates"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	entry: config.client.entry(),
 	output: config.client.output(),
 	resolve: {
-		extensions: ['.js', '.html']
+		extensions: ['.js', '.html', '.ts']
 	},
 	module: {
 		rules: [
@@ -25,6 +25,10 @@ module.exports = {
 						store: true
 					}
 				}
+			},
+			{
+				test: /\.ts$/,
+				loader: 'ts-loader'
 			},
 			isDev && {
 				test: /\.css$/,

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	output: config.server.output(),
 	target: 'node',
 	resolve: {
-		extensions: ['.js', '.html']
+		extensions: ['.js', '.html', '.ts']
 	},
 	module: {
 		rules: [
@@ -24,6 +24,10 @@ module.exports = {
 						generate: 'ssr'
 					}
 				}
+			},
+			{
+				test: /\.ts$/,
+				loader: 'ts-loader'
 			}
 		]
 	}


### PR DESCRIPTION
Will bring TypeScript support to `sapper-template` in conjunction with https://github.com/sveltejs/sapper/pull/81.

The `tsconfig.json` file is copied from `sapper`, but includes the `routes` and `templates` folders instead.

This and https://github.com/sveltejs/sapper/pull/81 together resolve https://github.com/sveltejs/sapper/issues/57.