### PR TITLE
Optimize Webpack "process" env

### DIFF
--- a/webpack.client.config.js
+++ b/webpack.client.config.js
@@ -51,6 +51,10 @@ module.exports = {
 	].concat(isDev ? [
 		new webpack.HotModuleReplacementPlugin()
 	] : [
+		new webpack.DefinePlugin({
+			'process.browser': true,
+			'process.env.NODE_ENV': '"production"'
+		}),
 		new ExtractTextPlugin('main.css'),
 		new webpack.optimize.ModuleConcatenationPlugin(),
 		new UglifyJSPlugin()


### PR DESCRIPTION
This removes roughly 1.63KB of the unnecessary "process" module, assuming the user is using idioms like `process.browser` and `process.env.NODE_ENV`.