### PR TITLE
Remove license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,3 @@ now
 ## Bugs and feedback
 
 Sapper is in early development, and may have the odd rough edge here and there. Please be vocal over on the [Sapper issue tracker](https://github.com/sveltejs/sapper/issues).
-
-
-## License
-
-[LIL](LICENSE)


### PR DESCRIPTION
Remove license section as mentioned in https://github.com/sveltejs/sapper-template/issues/28, plus the link is broken.