### PR TITLE
Do not cache with Cache API if cache mode is only-if-cached

### DIFF
--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -58,6 +58,8 @@ self.addEventListener('fetch', event => {
 	}
 	*/
 
+	if (event.request.cache === 'only-if-cached') return;
+
 	// for everything else, try the network first, falling back to
 	// cache if the user is offline. (If the pages never change, you
 	// might prefer a cache-first approach to a network-first one.)
@@ -66,11 +68,6 @@ self.addEventListener('fetch', event => {
 			.open(`offline${timestamp}`)
 			.then(async cache => {
 				try {
-					if (event.request.cache === 'only-if-cache') {
-						// workaround Chrome devtools bug https://github.com/sveltejs/sapper-template/issues/34
-						event.request.mode = 'same-origin';
-					}
-
 					const response = await fetch(event.request);
 					cache.put(event.request, response.clone());
 					return response;


### PR DESCRIPTION
The previous implementation tried to cache `only-if-cached` by changing
request mode but it doesn't work because the property is readonly.

However, caching responses cached with HTTP Cache again with Cache API
does not make sense anyway. Just do not cache it, and leave it to HTTP
cache.

Resolves https://github.com/sveltejs/sapper-template/issues/34#issuecomment-401404754. I made this change according to WHATWG Fetch Standard. Please tell me if you found something incompatible with the specification.