### PR TITLE
docs: fix git specifier for rollup version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A version of the default [Sapper](https://github.com/sveltejs/sapper) template that uses Rollup instead of webpack. To clone it and get started:
 
 ```bash
-npx degit sveltejs/sapper-template-rollup my-app
+npx degit sveltejs/sapper-template#rollup my-app
 cd my-app
 npm install # or yarn!
 npm run dev


### PR DESCRIPTION
`sveltejs/sapper-template-rollup` doesn't exist, but `sveltejs/sapper-template` has a `rollup` branch. Fixed the docs to refer to the branch since I assume that was the intent all along.