### PR TITLE
use service-worker-index.html in commented code

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -48,12 +48,12 @@ self.addEventListener('fetch', event => {
 		return;
 	}
 
-	// for pages, you might want to serve a shell `index.html` file,
+	// for pages, you might want to serve a shell `service-worker-index.html` file,
 	// which Sapper has generated for you. It's not right for every
 	// app, but if it's right for yours then uncomment this section
 	/*
 	if (url.origin === self.origin && routes.find(route => route.pattern.test(url.pathname))) {
-		event.respondWith(caches.match('/index.html'));
+		event.respondWith(caches.match('/service-worker-index.html'));
 		return;
 	}
 	*/


### PR DESCRIPTION
This is the sister PR to https://github.com/sveltejs/sapper/pull/525. All it does is change a code comment to reference `service-worker-index.html`. The old `index.html` hasn't worked for a while anyway.