### PR TITLE
removed experimentalCodeSplitting options

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -49,9 +49,6 @@ export default {
 				module: true
 			})
 		],
-
-		// temporary, pending Rollup 1.0
-		experimentalCodeSplitting: true
 	},
 
 	server: {
@@ -72,9 +69,6 @@ export default {
 		external: Object.keys(pkg.dependencies).concat(
 			require('module').builtinModules || Object.keys(process.binding('natives'))
 		),
-
-		// temporary, pending Rollup 1.0
-		experimentalCodeSplitting: true
 	},
 
 	serviceworker: {


### PR DESCRIPTION
experimentalCodeSplitting options no longer needed with Rollup 1.0+ (https://github.com/rollup/rollup/releases/tag/v1.0.0)