### PR TITLE
Update rollup-plugin-terser

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "compression": "^1.7.1",
-    "polka": "^0.4.0",
+    "polka": "^0.5.0",
     "sirv": "^0.2.0"
   },
   "devDependencies": {
@@ -40,7 +40,7 @@
         "rollup-plugin-node-resolve": "^4.0.0",
         "rollup-plugin-replace": "^2.0.0",
         "rollup-plugin-svelte": "^5.0.1",
-        "rollup-plugin-terser": "^1.0.1"
+        "rollup-plugin-terser": "^4.0.4"
       }
     },
     "webpack": {


### PR DESCRIPTION
This fixes this warning:
> The transformBundle hook used by plugin terser is deprecated. The renderChunk hook should be used instead.

Also update polka => everything is up-to-date