### PR TITLE
Add lang attribute to html template

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
 	<meta charset='utf-8'>
 	<meta name='viewport' content='width=device-width'>


### PR DESCRIPTION
I got warning in Visual Studio Code saying

```
The head element represents a collection of metadata for the Document.

A11y: <html> element should have a lang attributesvelte(a11y-missing-attribute)
```

And this fix the problem