### PR TITLE
Remove chokidar devDependency

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -33,7 +33,6 @@
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/runtime": "^7.0.0",
-        "chokidar": "^2.0.4",
         "rollup": "^1.0.0",
         "rollup-plugin-babel": "^4.0.2",
         "rollup-plugin-commonjs": "^9.1.6",


### PR DESCRIPTION
From v0.17.0 onwards, [Sapper uses cheap-watch instead of chokidar.](https://github.com/sveltejs/sapper/pull/365)

Live reloading works when you create a project with `npx degit sveltejs/sapper-template#rollup` and remove chokidar from the resulting *package.json* before installing. Nothing else in the project depends on chokidar.

Closes https://github.com/sveltejs/sapper-template/issues/129