### PR TITLE
Update README for v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm run dev
 
 Open up [localhost:3000](http://localhost:3000) and start clicking around.
 
-Consult [sapper.svelte.technology](https://sapper.svelte.technology) for help getting started.
+Consult [sapper.svelte.dev](https://sapper.svelte.dev) for help getting started.
 
 
 ## Structure
@@ -31,14 +31,14 @@ The [src](src) directory contains the entry points for your app — `client.js`,
 
 This is the heart of your Sapper app. There are two kinds of routes — *pages*, and *server routes*.
 
-**Pages** are Svelte components written in `.html` files. When a user first visits the application, they will be served a server-rendered version of the route in question, plus some JavaScript that 'hydrates' the page and initialises a client-side router. From that point forward, navigating to other pages is handled entirely on the client for a fast, app-like feel. (Sapper will preload and cache the code for these subsequent pages, so that navigation is instantaneous.)
+**Pages** are Svelte components written in `.svelte` files. When a user first visits the application, they will be served a server-rendered version of the route in question, plus some JavaScript that 'hydrates' the page and initialises a client-side router. From that point forward, navigating to other pages is handled entirely on the client for a fast, app-like feel. (Sapper will preload and cache the code for these subsequent pages, so that navigation is instantaneous.)
 
 **Server routes** are modules written in `.js` files, that export functions corresponding to HTTP methods. Each function receives Express `request` and `response` objects as arguments, plus a `next` function. This is useful for creating a JSON API, for example.
 
 There are three simple rules for naming the files that define your routes:
 
-* A file called `src/routes/about.html` corresponds to the `/about` route. A file called `src/routes/blog/[slug].html` corresponds to the `/blog/:slug` route, in which case `params.slug` is available to the route
-* The file `src/routes/index.html` (or `src/routes/index.js`) corresponds to the root of your app. `src/routes/about/index.html` is treated the same as `src/routes/about.html`.
+* A file called `src/routes/about.svelte` corresponds to the `/about` route. A file called `src/routes/blog/[slug].svelte` corresponds to the `/blog/:slug` route, in which case `params.slug` is available to the route
+* The file `src/routes/index.svelte` (or `src/routes/index.js`) corresponds to the root of your app. `src/routes/about/index.svelte` is treated the same as `src/routes/about.svelte`.
 * Files and directories with a leading underscore do *not* create routes. This allows you to colocate helper modules and components with the routes that depend on them — for example you could have a file called `src/routes/_helpers/datetime.js` and it would *not* create a `/_helpers/datetime` route
 
 
@@ -49,7 +49,7 @@ The [static](static) directory contains any static assets that should be availab
 In your [service-worker.js](app/service-worker.js) file, you can import these as `files` from the generated manifest...
 
 ```js
-import { files } from '../__sapper__/service-worker.js';
+import { files } from '@sapper/service-worker';
 ```
 
 ...so that you can cache them (though you can choose not to, for example if you don't want to cache very large files).
@@ -76,7 +76,7 @@ now
 
 When using Svelte components installed from npm, such as [@sveltejs/svelte-virtual-list](https://github.com/sveltejs/svelte-virtual-list), Svelte needs the original component source (rather than any precompiled JavaScript that ships with the component). This allows the component to be rendered server-side, and also keeps your client-side app smaller.
 
-Because of that, it's essential that webpack doesn't treat the package as an *external dependency*. You can either modify the `externals` option in [webpack/server.config.js](webpack/server.config.js), or simply install the package to `devDependencies` rather than `dependencies`, which will cause it to get bundled (and therefore compiled) with your app:
+Because of that, it's essential that webpack doesn't treat the package as an *external dependency*. You can either modify the `externals` option under `server` in [webpack.config.js](webpack.config.js), or simply install the package to `devDependencies` rather than `dependencies`, which will cause it to get bundled (and therefore compiled) with your app:
 
 ```bash
 yarn add -D @sveltejs/svelte-virtual-list


### PR DESCRIPTION
- New URL (sapper.svelte.dev)
- Reflect the file structure of the current template, with .svelte pages
- Fix webpack config filename https://github.com/sveltejs/sapper-template/commit/8e3a89468e02c99291420263c3ee1b5bf9a7cc98#diff-11e9f7f953edc64ba14b0cc350ae7b9d