### PR TITLE
rollup: suppress `@sapper` circular dependency warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,8 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
+const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && warning.message.includes('/@sapper/')) || onwarn(warning);
+
 export default {
 	client: {
 		input: config.client.input(),
@@ -49,6 +51,8 @@ export default {
 				module: true
 			})
 		],
+
+		onwarn,
 	},
 
 	server: {
@@ -69,6 +73,8 @@ export default {
 		external: Object.keys(pkg.dependencies).concat(
 			require('module').builtinModules || Object.keys(process.binding('natives'))
 		),
+
+		onwarn,
 	},
 
 	serviceworker: {
@@ -82,6 +88,8 @@ export default {
 			}),
 			commonjs(),
 			!dev && terser()
-		]
+		],
+
+		onwarn,
 	}
 };


### PR DESCRIPTION
Resolves #145. It's ugly, but I am almost positive that this will solve infinitely more problems than it causes.