### PR TITLE
Bug fix - cached files now serving in offline too

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -43,7 +43,7 @@ self.addEventListener('fetch', event => {
 	if (url.hostname === self.location.hostname && url.port !== self.location.port) return;
 
 	// always serve static files and bundler-generated assets from cache
-	if (url.host === self.location.host && cached.has(url.pathname)) {
+	if (url.host === self.location.host && cached.has(url.pathname.slice(1))) {
 		event.respondWith(caches.match(event.request));
 		return;
 	}


### PR DESCRIPTION
I'm catched this issue on Windows 10.

Step-by-step what happens:
```js
const files = [
    // ...
    "favicon.png",
    // etc. (cache-able files)
];

const to_cache = shell.concat(files).filter(n => n !== '.DS_Store');
const cached = new Set(to_cache);


// Our listener
self.addEventListener('fetch', event => {
    // ...

    /*
     * We cannot pass this condition, cause of: url.pathname is equal to "/favicon.png"
     * the source: `cached.has(url.pathname)` which will become `cached.has("/favicon.png")`
     * this fix will do the thing: `cached.has(url.pathname.slice(1)` which will become `cached.has("favicon.png")`
     *      cached
     */
    if (url.host === self.location.host && cached.has(url.pathname.slice(1))) {
        // serving...
    }

    // ...
});
```
