### PR TITLE
Add browser:true to rollup-plugin-node-resolve for client build.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,9 @@ export default {
 				hydratable: true,
 				emitCss: true
 			}),
-			resolve(),
+			resolve({
+				browser: true
+			}),
 			commonjs(),
 
 			legacy && babel({


### PR DESCRIPTION
I'm sick of debugging bundler problems because of Axios. 

This adds the `browser:true` to the rollup-plugin-node-resolve options for the client build only. This should be useful for any libraries that specify a separate browser build using the browser field in `package.json`. I don't think it would cause any problems (it should be ignored if the browser field isn't used).

The webpack client build already resolves the browser field, if my naive reading of the webpack config is correct.

If it will cause problems that you know of, feel free to decline and I'll go back to my life of misery.