### PR TITLE
Ignoring query string in static files

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -44,7 +44,15 @@ self.addEventListener('fetch', event => {
 
 	// always serve static files and bundler-generated assets from cache
 	if (url.host === self.location.host && cached.has(url.pathname)) {
-		event.respondWith(caches.match(event.request));
+		event.respondWith(
+			caches.match(event.request, {
+				/**
+				 * Ignoring query string, for example ignore `?foo=bar` in `/logo.svg?foo=bar`
+				 * Read more about cache.match options: http://bit.ly/2Is35VP
+				 */
+				'ignoreSearch': true,
+			})
+		);
 		return;
 	}
 


### PR DESCRIPTION
### Prerequisite
First you have to approve this PR https://github.com/sveltejs/sapper-template/pull/148 to serve cached files through service-worker.

### About this PR
If you try to open static file (which has been cached), for example borat pic in the example app:
> https://sapper-template.now.sh/great-success.png
It will open successfully!

But if you try to add some query strings, e.g.: `?foo=bar`, then it will not work*:
> https://sapper-template.now.sh/great-success.png?foo=bar
*if you approved this PR https://github.com/sveltejs/sapper-template/pull/148

#### So this PR solves above bug and ignores query strings.