### PR TITLE
[Naive fix] Enable to deploy to now v2

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,0 +1,12 @@
+{
+    "version": 2,
+    "name": "sapper-template",
+    "alias": "sapper-template",
+    "builds": [
+      {
+        "src": "__sapper__/build/index.js",
+        "use": "now-sapper"
+      }
+    ],
+    "routes": [{ "src": "/(.*)", "dest": "__sapper__/build/index.js" }]
+  } 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,6 @@ import svelte from 'rollup-plugin-svelte';
 import babel from 'rollup-plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 import config from 'sapper/config/rollup.js';
-import pkg from './package.json';
 
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
@@ -72,7 +71,7 @@ export default {
 			resolve(),
 			commonjs()
 		],
-		external: Object.keys(pkg.dependencies).concat(
+		external: [].concat(
 			require('module').builtinModules || Object.keys(process.binding('natives'))
 		),
 

--- a/src/server.js
+++ b/src/server.js
@@ -6,12 +6,17 @@ import * as sapper from '@sapper/server';
 const { PORT, NODE_ENV } = process.env;
 const dev = NODE_ENV === 'development';
 
-polka() // You can also use Express
+const app = polka() // You can also use Express
 	.use(
 		compression({ threshold: 0 }),
 		sirv('static', { dev }),
 		sapper.middleware()
 	)
-	.listen(PORT, err => {
-		if (err) console.log('error', err);
-	});
+
+export default app.handler;
+
+if (!process.env.NOW_REGION) {
+	app.listen(PORT, err => {
+		if (err) console.log('error', err)
+	})
+}  

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const webpack = require('webpack');
 const config = require('sapper/config/webpack.js');
-const pkg = require('./package.json');
 
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
@@ -45,7 +44,7 @@ module.exports = {
 		output: config.server.output(),
 		target: 'node',
 		resolve: { extensions, mainFields },
-		externals: Object.keys(pkg.dependencies).concat('encoding'),
+		externals: [].concat('encoding'),
 		module: {
 			rules: [
 				{


### PR DESCRIPTION
Naive fix of now v2 support as discussed on issue :
https://github.com/sveltejs/sapper/issues/564

- ADD default now.json file (enable to follow sapper docs, especially the now part)
- ADD export of Polka handler (same reason as above)
- DEL rollup and webpack "pkg" dependencies ==> This one I don't really understand and just followed suggestion from @danielschmitz 

[Disclaimer] I am no Javascript expert therefore suspect to have missed potential impacts on the template.

Feedback are obviously welcomed :) 