### PR TITLE
Fixed: VSCode warning in package.json or package_template.json

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -1,6 +1,6 @@
 {
-  "name": "TODO",
-  "description": "TODO",
+  "name": "todo",
+  "description": "todo",
   "version": "0.0.1",
   "scripts": {
     "dev": "sapper dev",


### PR DESCRIPTION
On cloning this repository using degit you get warning (tested in VS Code) that 
![fixthis](https://user-images.githubusercontent.com/47381044/60566350-1da15d80-9d80-11e9-8c41-2afe5a12c981.png)

I have change package name from "TODO" to "todo" so VS Code does not give this warning any more. 