### PR TITLE
Add ~ alias to webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,10 @@ const pkg = require('./package.json');
 const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 
-const alias = { svelte: path.resolve('node_modules', 'svelte') };
+const alias = {
+	svelte: path.resolve('node_modules', 'svelte'),
+	'~': `${__dirname}/src`
+};
 const extensions = ['.mjs', '.js', '.json', '.svelte', '.html'];
 const mainFields = ['svelte', 'module', 'browser', 'main'];
 


### PR DESCRIPTION
Add `~` alias. This will allow users to use in their svelte apps the `~` alias like this:

```
  import AddUser from '~/components/AddUser.svelte';
```
instead of:
```
  import AddUser from './AddUser.svelte';
```
or
```
  import AddUser from '../../../AddUser.svelte';
```
or
```
  import AddUser from '../components/AddUser.svelte';
```

this would make it easier to leave nuxt: https://nuxtjs.org/guide/directory-structure/#aliases