### PR TITLE
Update `dev` and `mode` to fix #58

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ const path = require('path');
 const config = require('sapper/config/webpack.js');
 const pkg = require('./package.json');
 
-const mode = process.env.NODE_ENV;
-const dev = mode === 'development';
+const dev = process.env.NODE_ENV === 'development';
+const mode = dev ? 'development' : 'production';
 
 const alias = { svelte: path.resolve('node_modules', 'svelte') };
 const extensions = ['.mjs', '.js', '.json', '.svelte', '.html'];
@@ -63,7 +63,7 @@ module.exports = {
 				}
 			]
 		},
-		mode: process.env.NODE_ENV,
+		mode,
 		performance: {
 			hints: false // it doesn't matter if server.js is large
 		}
@@ -72,6 +72,6 @@ module.exports = {
 	serviceworker: {
 		entry: config.serviceworker.entry(),
 		output: config.serviceworker.output(),
-		mode: process.env.NODE_ENV
+		mode
 	}
 };


### PR DESCRIPTION
Defaults `mode` to 'production' when not 'development', as opposed to passing `NODE_ENV` values like 'staging'.