### PR TITLE
Preserve non-generated code in src/node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /node_modules/
 /src/node_modules/@sapper/
+!/src/node_modules
 yarn-error.log
 /cypress/screenshots/
 /__sapper__/


### PR DESCRIPTION
You can't pave the way for a revolution if you delete everyone's files ;)

Added a `.gitignore` override for non-generated code (everything else) in `src/node_modules`.