### PR TITLE
feat: Use aria-current instead of visual only indicator

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -26,12 +26,12 @@
 		float: left;
 	}
 
-	.selected {
+	[aria-current] {
 		position: relative;
 		display: inline-block;
 	}
 
-	.selected::after {
+	[aria-current]::after {
 		position: absolute;
 		content: '';
 		width: calc(100% - 1em);
@@ -50,11 +50,11 @@
 
 <nav>
 	<ul>
-		<li><a class='{segment === undefined ? "selected" : ""}' href='.'>home</a></li>
-		<li><a class='{segment === "about" ? "selected" : ""}' href='about'>about</a></li>
+		<li><a aria-current='{segment === undefined ? "page" : undefined}' href='.'>home</a></li>
+		<li><a aria-current='{segment === "about" ? "page" : undefined}' href='about'>about</a></li>
 
 		<!-- for the blog link, we're using rel=prefetch so that Sapper prefetches
 		     the blog data when we hover over the link or tap it on a touchscreen -->
-		<li><a rel=prefetch class='{segment === "blog" ? "selected" : ""}' href='blog'>blog</a></li>
+		<li><a rel=prefetch aria-current='{segment === "blog" ? "page" : undefined}' href='blog'>blog</a></li>
 	</ul>
 </nav>


### PR DESCRIPTION
Preserves the visual styling and adds hints to AT. For example NVDA will now read

```diff
home
-visited  link
+visited  link  current page
blog
link
about
link
blog
link
home
-visited  link
+visited  link  current page
```
when tabbing through the list.

[`aria-current` spec](https://www.w3.org/TR/wai-aria-1.1/#aria-current)