### PR TITLE
Remove ZEIT Now Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,7 @@ Sapper uses Rollup or webpack to provide code-splitting and dynamic imports, as 
 
 To start a production version of your app, run `npm run build && npm start`. This will disable live reloading, and activate the appropriate bundler plugins.
 
-You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [Now](https://zeit.co/now), run these commands:
-
-```bash
-npm install -g now
-now
-```
+You can deploy your application to any environment that supports Node 8 or above.
 
 
 ## Using external components


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/sveltejs/sapper/issues/564) - Sapper is not quite ready for SSR in a serverless environment and is only available therefore with `sapper export`.

This PR removes ZEIT Now as a deployment example to prevent any confusion with users looking to deploy an SSR Sapper app.