### PR TITLE
Update Deployment Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,7 @@ npm install -g now
 now
 ```
 
-If using Sapper with SSR on Now, it is recommended to use the [now-sapper](https://github.com/thgh/now-sapper) Builder, with a `now.json` config like below:
-
-```
-{
-  "version": 2,
-    "builds": [
-    { "src": "package.json", "use": "now-sapper" }
-  ],
-}
-```
-
-You should read the [usage section](https://github.com/thgh/now-sapper#basic-usage) of the repository for more information.
+If using Sapper with SSR on Now, it is recommended to use the [now-sapper](https://github.com/thgh/now-sapper) Builder, you can find instructions on how to do so in the [README](https://github.com/thgh/now-sapper#basic-usage).
 
 
 ## Using external components

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Sapper uses Rollup or webpack to provide code-splitting and dynamic imports, as 
 
 To start a production version of your app, run `npm run build && npm start`. This will disable live reloading, and activate the appropriate bundler plugins.
 
-You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [ZEIT Now](https://zeit.co/now) when using `sapper export`, run these commands:
+You can deploy your application to any environment that supports Node 10 or above. As an example, to deploy to [ZEIT Now](https://zeit.co/now) when using `sapper export`, run these commands:
 
 ```bash
 npm install -g now

--- a/README.md
+++ b/README.md
@@ -85,12 +85,25 @@ Sapper uses Rollup or webpack to provide code-splitting and dynamic imports, as 
 
 To start a production version of your app, run `npm run build && npm start`. This will disable live reloading, and activate the appropriate bundler plugins.
 
-You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [Now](https://zeit.co/now), run these commands:
+You can deploy your application to any environment that supports Node 8 or above. As an example, to deploy to [ZEIT Now](https://zeit.co/now) when using `sapper export`, run these commands:
 
 ```bash
 npm install -g now
 now
 ```
+
+If using Sapper with SSR on Now, it is recommended to use the [now-sapper](https://github.com/thgh/now-sapper) Builder, with a `now.json` config like below:
+
+```
+{
+  "version": 2,
+    "builds": [
+    { "src": "package.json", "use": "now-sapper" }
+  ],
+}
+```
+
+You should read the [usage section](https://github.com/thgh/now-sapper#basic-usage) of the repository for more information.
 
 
 ## Using external components

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ npm install -g now
 now
 ```
 
-If using Sapper with SSR on Now, it is recommended to use the [now-sapper](https://github.com/thgh/now-sapper) Builder, you can find instructions on how to do so in the [README](https://github.com/thgh/now-sapper#basic-usage).
+If your app can't be exported to a static site, you can use the [now-sapper](https://github.com/thgh/now-sapper) builder. You can find instructions on how to do so in its [README](https://github.com/thgh/now-sapper#basic-usage).
 
 
 ## Using external components


### PR DESCRIPTION
This PR updates the deployment section to advise the use of `now-sapper` for deploying to ZEIT Now when using SSR.

@antony please let me know your thoughts, we can iterate if required 👍 