### PR TITLE
Update TODO to Sapper template

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -1,6 +1,6 @@
 {
-  "name": "TODO",
-  "description": "TODO",
+  "name": "Sapper template",
+  "description": "Sapper template",
   "version": "0.0.1",
   "scripts": {
     "dev": "sapper dev",


### PR DESCRIPTION
We should rename the `name` and `description` fields, in `package.json` from `TODO` to something else. Maybe just `Sapper template`?