### PR TITLE
use improved dedupe in @rollup/plugin-node-resolve@7

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -34,7 +34,7 @@
         "@babel/preset-env": "^7.0.0",
         "@babel/runtime": "^7.0.0",
         "@rollup/plugin-commonjs": "^11.0.0",
-        "@rollup/plugin-node-resolve": "^6.0.0",
+        "@rollup/plugin-node-resolve": "^7.0.0",
         "@rollup/plugin-replace": "^2.2.0",
         "rollup": "^1.20.0",
         "rollup-plugin-babel": "^4.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,6 @@ const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
 const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);
-const dedupe = importee => importee === 'svelte' || importee.startsWith('svelte/');
 
 export default {
 	client: {
@@ -30,7 +29,7 @@ export default {
 			}),
 			resolve({
 				browser: true,
-				dedupe
+				dedupe: ['svelte']
 			}),
 			commonjs(),
 
@@ -72,7 +71,7 @@ export default {
 				dev
 			}),
 			resolve({
-				dedupe
+				dedupe: ['svelte']
 			}),
 			commonjs()
 		],


### PR DESCRIPTION
https://github.com/rollup/plugins/pull/99 introduced a change to how `dedupe` works. It now matches just the package name, so we can use the array syntax, which is a bit less confusing.