### PR TITLE
Add manifest crossorigin="use-credentials"

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -8,7 +8,7 @@
 	%sapper.base%
 
 	<link rel='stylesheet' href='global.css'>
-	<link rel='manifest' href='manifest.json'>
+	<link rel='manifest' href='manifest.json' crossorigin='use-credentials'>
 	<link rel='icon' type='image/png' href='favicon.png'>
 
 	<!-- Sapper generates a <style> tag containing critical CSS


### PR DESCRIPTION
Including `crossorigin` attribute on manifest link helps us to avoid additional TLS connection. Streamlines loading of manifest.json and app icons.

Ref: 
https://twitter.com/TimVereecke/status/1225547620791341062
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#Example_Webmanifest_with_credentials

Trims a few hundred milliseconds off request over 3G:

**Before:** 
![Screenshot-2020-02-08-at-12 19 50](https://user-images.githubusercontent.com/2671053/74085238-eb22b600-4a6e-11ea-98fc-d0ea0c7b0d7b.jpg)

**After:**
![Screenshot-2020-02-08-at-12 20 11](https://user-images.githubusercontent.com/2671053/74085242-f2e25a80-4a6e-11ea-8016-d0b3f2338d28.jpg)

Worth doing some further testing, but may improve boot-up time of app when running as a PWA?