### PR TITLE
Adds compatibility with Yarn 2

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -33,6 +33,7 @@
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/runtime": "^7.0.0",
+        "@rollup/plugin-alias": "^3.0.0",
         "@rollup/plugin-commonjs": "^11.0.0",
         "@rollup/plugin-node-resolve": "^7.0.0",
         "@rollup/plugin-replace": "^2.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import alias from '@rollup/plugin-alias';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
@@ -26,6 +27,12 @@ export default {
 				dev,
 				hydratable: true,
 				emitCss: true
+			}),
+			alias({
+				entries: [{
+					find: `@sapper`,
+					replacement: `${__dirname}/src/node_modules/@sapper`
+				}]
 			}),
 			resolve({
 				browser: true,
@@ -70,6 +77,12 @@ export default {
 				generate: 'ssr',
 				dev
 			}),
+			alias({
+				entries: [{
+					find: `@sapper`,
+					replacement: `${__dirname}/src/node_modules/@sapper`
+				}]
+			}),
 			resolve({
 				dedupe: ['svelte']
 			}),
@@ -90,6 +103,12 @@ export default {
 			replace({
 				'process.browser': true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
+			}),
+			alias({
+				entries: [{
+					find: `@sapper`,
+					replacement: `${__dirname}/src/node_modules/@sapper`
+				}]
 			}),
 			commonjs(),
 			!dev && terser()


### PR DESCRIPTION
Sapper generates packages at runtime into `src/node_modules`. Since Yarn 2 controls by default the whole resolution (which is required in order to throw semantic errors explaining why the resolution fails), it isn't aware that those packages exist and the build fails.

The fix is simply to explicit that the `@sapper` namespace is meant to be searched inside `src/node_modules` by using the Alias plugin.
