### PR TITLE
Update blog docs url path from html to svelte

### DIFF
--- a/src/routes/blog/_posts.js
+++ b/src/routes/blog/_posts.js
@@ -69,7 +69,7 @@ const posts = [
 
 			<ul>
 				<li>It's powered by <a href='https://svelte.dev'>Svelte</a> instead of React, so it's faster and your apps are smaller</li>
-				<li>Instead of route masking, we encode route parameters in filenames. For example, the page you're looking at right now is <code>src/routes/blog/[slug].html</code></li>
+				<li>Instead of route masking, we encode route parameters in filenames. For example, the page you're looking at right now is <code>src/routes/blog/[slug].svelte</code></li>
 				<li>As well as pages (Svelte components, which render on server or client), you can create <em>server routes</em> in your <code>routes</code> directory. These are just <code>.js</code> files that export functions corresponding to HTTP methods, and receive Express <code>request</code> and <code>response</code> objects as arguments. This makes it very easy to, for example, add a JSON API such as the one <a href='blog/how-is-sapper-different-from-next.json'>powering this very page</a></li>
 				<li>Links are just <code>&lt;a&gt;</code> elements, rather than framework-specific <code>&lt;Link&gt;</code> components. That means, for example, that <a href='blog/how-can-i-get-involved'>this link right here</a>, despite being inside a blob of HTML, works with the router as you'd expect.</li>
 			</ul>


### PR DESCRIPTION
Hello! I noticed in the blog docs post titled `How is Sapper different from Next.js?`
the second bullet says this

```
For example, the page you're looking at right now is src/routes/blog/[slug].html
```

and would like to change it to 
```
For example, the page you're looking at right now is src/routes/blog/[slug].svelte
```