### PR TITLE
deudpe svelte internal to make npm link work

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
 const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);
+const dedupe = ['svelte', 'svelte/internal'];
 
 export default {
 	client: {
@@ -29,7 +30,7 @@ export default {
 			}),
 			resolve({
 				browser: true,
-				dedupe: ['svelte']
+				dedupe
 			}),
 			commonjs(),
 
@@ -71,7 +72,7 @@ export default {
 				dev
 			}),
 			resolve({
-				dedupe: ['svelte']
+				dedupe
 			}),
 			commonjs()
 		],


### PR DESCRIPTION
Based on this issue https://github.com/sveltejs/rollup-plugin-svelte/issues/55

Stops this rather painful issue which prevents your app from working when another Svelte component is `npm link`ed in for development

```
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/DiscIcon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/DollarSignIcon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/DownloadCloudIcon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/DownloadIcon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/DropletIcon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/Edit2Icon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/Edit3Icon.svelte, but could not be resolved – treating it as an external dependency
'svelte/internal' is imported by ../beyonk-shared/packages/fields/node_modules/svelte-feather-icons/src/icons/CropIcon.svelte, but could not be resolved – treating it as an external dependency
```