### PR TITLE
[Sapper #1151] Updated rollup dependencies

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -34,10 +34,10 @@
         "@babel/preset-env": "^7.0.0",
         "@babel/runtime": "^7.0.0",
         "@rollup/plugin-babel": "^5.0.0",
-        "@rollup/plugin-commonjs": "11.0.2",
+        "@rollup/plugin-commonjs": "^12.0.0",
         "@rollup/plugin-node-resolve": "^7.0.0",
         "@rollup/plugin-replace": "^2.2.0",
-        "rollup": "^2.0.0",
+        "rollup": "^2.3.4",
         "rollup-plugin-svelte": "^5.0.1",
         "rollup-plugin-terser": "^5.3.0"
       }

--- a/package_template.json
+++ b/package_template.json
@@ -33,11 +33,11 @@
         "@babel/plugin-transform-runtime": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/runtime": "^7.0.0",
+        "@rollup/plugin-babel": "^5.0.0",
         "@rollup/plugin-commonjs": "11.0.2",
         "@rollup/plugin-node-resolve": "^7.0.0",
         "@rollup/plugin-replace": "^2.2.0",
-        "rollup": "^1.20.0",
-        "rollup-plugin-babel": "^4.0.2",
+        "rollup": "^2.7.6",
         "rollup-plugin-svelte": "^5.0.1",
         "rollup-plugin-terser": "^5.3.0"
       }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import commonjs from '@rollup/plugin-commonjs';
 import svelte from 'rollup-plugin-svelte';
-import babel from 'rollup-plugin-babel';
+import babel from '@rollup/plugin-babel';
 import { terser } from 'rollup-plugin-terser';
 import config from 'sapper/config/rollup.js';
 import pkg from './package.json';
@@ -55,6 +55,7 @@ export default {
 			})
 		],
 
+		preserveEntrySignatures: false,
 		onwarn,
 	},
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default {
 
 			legacy && babel({
 				extensions: ['.js', '.mjs', '.html', '.svelte'],
-				runtimeHelpers: true,
+				babelHelpers: 'runtime',
 				exclude: ['node_modules/@babel/**'],
 				presets: [
 					['@babel/preset-env', {


### PR DESCRIPTION
This is not ready for merging until an issue for `@rollup/plugin-commonjs` is fixed, which should be any day: https://github.com/rollup/plugins/issues/304

Before merging this PR should update that dependency to the fix first.

Relevant Sapper issue: https://github.com/sveltejs/sapper/issues/1151

Will also fix: sveltejs/sapper-template#218