### PR TITLE
gitpod set up

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install
+    command: npm run dev
+vscode:
+  extensions:
+    - JamesBirtles.svelte-vscode@0.9.3:aT2nc+VyKmuFE9yDTcvKcw==

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.autoSave": "on"
+}


### PR DESCRIPTION
Install gitpod browser extension in firefox or chrome, then push the gitpod button when viewing this pr.

This pr sets up the gitpod environment for svelte. It will install and run the app. A prompt will request opening the 3000 port in the browser.

Cheers, Mark

p.s. once satisfied a ready-to-code badge can be added to the repo and in that case users would not need to install the gitpod browser extension. This is the typical use case.