### PR TITLE
Remove unused fallback

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -76,9 +76,7 @@ export default {
 			}),
 			commonjs()
 		],
-		external: Object.keys(pkg.dependencies).concat(
-			require('module').builtinModules || Object.keys(process.binding('natives'))
-		),
+		external: Object.keys(pkg.dependencies).concat(require('module').builtinModules),
 
 		preserveEntrySignatures: 'strict',
 		onwarn,


### PR DESCRIPTION
According to the comment in https://github.com/sveltejs/sapper-template/issues/206#issuecomment-596485705 this code is no longer used after we've upgraded to Rollup 2, which happened awhile ago