### PR TITLE
Silence preload export warnings related to TypeScript support

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,9 +12,9 @@ const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
 const onwarn = (warning, onwarn) =>
-	   (warning.code === 'MISSING_EXPORT' && /'preload'/.test(warning.message))
-	|| (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message))
-	|| onwarn(warning);
+	(warning.code === 'MISSING_EXPORT' && /'preload'/.test(warning.message)) ||
+	(warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) ||
+	onwarn(warning);
 
 export default {
 	client: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,10 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
-const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);
+const onwarn = (warning, onwarn) =>
+	   (warning.code === 'MISSING_EXPORT' && /'preload'/.test(warning.message))
+	|| (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message))
+	|| onwarn(warning);
 
 export default {
 	client: {


### PR DESCRIPTION
In https://github.com/sveltejs/sapper/pull/1344 we decided to implement in a way that would create warnings and then silence them in the template