### PR TITLE
Remove "Rollup" from setupTypeScript script name in rollup branch

### DIFF
--- a/_template/create-branches.sh
+++ b/_template/create-branches.sh
@@ -14,6 +14,7 @@ git reset $HEAD --hard
 node _template/build-pkg.js rollup
 git rm -r --cached .github _template package_template.json webpack.config.js
 git add package.json
+git mv scripts/setupTypeScriptRollup.js scripts/setupTypeScript.js
 git commit -m 'Sapper template for Rollup'
 
 # create the $WEBPACK branch off the current HEAD
@@ -22,4 +23,5 @@ git reset $HEAD --hard
 node _template/build-pkg.js webpack
 git rm -r --cached .github _template package_template.json rollup.config.js
 git add package.json
+git rm scripts/setupTypeScriptRollup.js
 git commit -m 'Sapper template for webpack'


### PR DESCRIPTION
Remove "Rollup" from setupTypeScript script name in rollup branch and remove it in webpack branch.

Fixes #268 

Blocks #1557 and #267