### PR TITLE
Add new line after inserted import statements

### DIFF
--- a/scripts/setupTypeScriptRollup.js
+++ b/scripts/setupTypeScriptRollup.js
@@ -142,7 +142,8 @@ function updateRollupConfig() {
 			/'rollup-plugin-terser';\n(?!import sveltePreprocess)/,
 			`'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
-import typescript from '@rollup/plugin-typescript';`
+import typescript from '@rollup/plugin-typescript';
+`
 		],
 		// Edit inputs
 		[


### PR DESCRIPTION
When running this script, the modified `rollup.config.js` file becomes:

```javascript
[...]
import babel from '@rollup/plugin-babel';
import { terser } from 'rollup-plugin-terser';
import sveltePreprocess from 'svelte-preprocess';
import typescript from '@rollup/plugin-typescript';import config from 'sapper/config/rollup.js';
import pkg from './package.json';
[...]
```

Thus, a new line should be added after the inserted import statements.