### PR TITLE
Emit css in modern build only

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ export default {
 			svelte({
 				dev,
 				hydratable: true,
-				emitCss: true
+				emitCss: !legacy
 			}),
 			resolve({
 				browser: true,


### PR DESCRIPTION
Currently the template rollup config emits CSS twice if you are running build with the `--legacy` command. This is resulting in duplicate css getting served to legacy browsers like IE. 

This change changes the config to only emit css on the first pass.