### PR TITLE
Service worker would fail if accessing static assets with query string

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -44,7 +44,7 @@ self.addEventListener('fetch', event => {
 
 	// always serve static files and bundler-generated assets from cache
 	if (url.host === self.location.host && cached.has(url.pathname)) {
-		event.respondWith(caches.match(event.request));
+		event.respondWith(caches.match(event.request, { ignoreSearch: true }));
 		return;
 	}
 


### PR DESCRIPTION
Fixes sveltejs/sapper#1587. The service worker would assume that is the request path matches an asset, then the asset is in the cache. It would then use CacheStorage.match to retrieve the request, but that would fail if the query string was different.

I don't think there's any reasonably simple way of writing a test for this unfortunately.