### PR TITLE
Point out that `npm run build` is required for @sapper imports

### DIFF
--- a/scripts/setupTypeScriptRollup.js
+++ b/scripts/setupTypeScriptRollup.js
@@ -242,5 +242,9 @@ if (!argv[2]) {
 console.log('Converted to TypeScript.');
 
 if (fs.existsSync(path.join(projectRoot, 'node_modules'))) {
-	console.log(`\nYou will need to re-run 'npm install' to get started.`);
+	console.log(`
+Next:
+1. run 'npm install' again to install TypeScript dependencies
+2. run 'npm run build' for the @sapper imports in your project to work
+`);
 }


### PR DESCRIPTION
After looking at sveltejs/sapper#1583 and being quite confused myself as to how the `@sapper` dependencies are resolved, added that information to the message in the `setupTypeScript` script.
