### PR TITLE
Update webpack file-loader config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ const alias = { svelte: path.resolve('node_modules', 'svelte') };
 const extensions = ['.mjs', '.js', '.json', '.svelte', '.html'];
 const mainFields = ['svelte', 'module', 'browser', 'main'];
 const fileLoaderRule = {
-	test: /\.(png|svg|jpg|gif)$/,
+	test: /\.(png|jpe?g|gif)$/i,
 	use: [
 		'file-loader',
 	]


### PR DESCRIPTION
Per @Conduitry's suggestion in https://github.com/sveltejs/sapper-template/pull/248#discussion_r505688786

It looks like this is now the config demonstrated in the webpack docs: https://webpack.js.org/loaders/file-loader/#getting-started

It looks like there's a separate inline svg loader, which is probably why they don't demonstrate that anymore