### PR TITLE
Added an ambient type declaration for allowing image imports

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -8,12 +8,32 @@
 		<img src="{successkid}">
 	 ```
  */
+declare module "*.gif" {
+	const value: string;
+	export = value;
+}
+
 declare module "*.jpg" {
-	const value: any;
+	const value: string;
+	export = value;
+}
+
+declare module "*.jpeg" {
+	const value: string;
 	export = value;
 }
 
 declare module "*.png" {
-	const value: any;
+	const value: string;
+	export = value;
+}
+
+declare module "*.svg" {
+	const value: string;
+	export = value;
+}
+
+declare module "*.webp" {
+	const value: string;
 	export = value;
 }

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,0 +1,19 @@
+/**
+ * These declarations tell TypeScript that we allow import of images, e.g.
+ * ```
+		<script lang='ts'>
+			import successkid from 'images/successkid.jpg';
+		</script>
+
+		<img src="{successkid}">
+	 ```
+ */
+declare module "*.jpg" {
+	const value: any;
+	export = value;
+}
+
+declare module "*.png" {
+	const value: any;
+	export = value;
+}


### PR DESCRIPTION
This fixes #281 or at least it fixes `svelte-check`.

The import is still reported as an error in VSCode but I suspect that is the same thing as sveltejs/language-tools#610

(There are plenty more file types we theoretically could add; not sure if it makes sense to add all of them from the beginning)