### PR TITLE
fix: Rollup replace plugin warnings

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -32,7 +32,7 @@
         "@rollup/plugin-babel": "^5.0.0",
         "@rollup/plugin-commonjs": "^14.0.0",
         "@rollup/plugin-node-resolve": "^8.0.0",
-        "@rollup/plugin-replace": "^2.2.0",
+        "@rollup/plugin-replace": "^2.4.0",
         "@rollup/plugin-url": "^5.0.0",
         "rollup": "^2.3.4",
         "rollup-plugin-svelte": "^7.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,9 @@ export default {
 		plugins: [
 			replace({
 				preventAssignment: true,
-				'process.browser': true,
+				values:{
+				  'process.browser': true,
+				},
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -76,7 +78,9 @@ export default {
 		plugins: [
 			replace({
 				preventAssignment: true,
-				'process.browser': false,
+				values:{
+				  'process.browser': true,
+				},
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -110,7 +114,9 @@ export default {
 			resolve(),
 			replace({
 				preventAssignment: true,
-				'process.browser': true,
+				values:{
+				  'process.browser': true,
+				},
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			commonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,8 +27,8 @@ export default {
 				preventAssignment: true,
 				values:{
 				  'process.browser': true,
+			          'process.env.NODE_ENV': JSON.stringify(mode)
 				},
-				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
 				compilerOptions: {
@@ -80,8 +80,8 @@ export default {
 				preventAssignment: true,
 				values:{
 				  'process.browser': true,
+				  'process.env.NODE_ENV': JSON.stringify(mode)
 				},
-				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
 				compilerOptions: {
@@ -116,8 +116,8 @@ export default {
 				preventAssignment: true,
 				values:{
 				  'process.browser': true,
+				  'process.env.NODE_ENV': JSON.stringify(mode)
 				},
-				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			commonjs(),
 			!dev && terser()

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default {
 				preventAssignment: true,
 				values:{
 				  'process.browser': true,
-			          'process.env.NODE_ENV': JSON.stringify(mode)
+			      'process.env.NODE_ENV': JSON.stringify(mode)
 				},
 			}),
 			svelte({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,8 +24,8 @@ export default {
 		output: config.client.output(),
 		plugins: [
 			replace({
+				preventAssignment: true,
 				'process.browser': true,
-				'preventAssignment': true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -75,8 +75,8 @@ export default {
 		output: config.server.output(),
 		plugins: [
 			replace({
+				preventAssignment: true,
 				'process.browser': false,
-				'preventAssignment': true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -109,8 +109,8 @@ export default {
 		plugins: [
 			resolve(),
 			replace({
+				preventAssignment: true,
 				'process.browser': true,
-				'preventAssignment': true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			commonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,8 +26,8 @@ export default {
 			replace({
 				preventAssignment: true,
 				values:{
-				  'process.browser': true,
-			      'process.env.NODE_ENV': JSON.stringify(mode)
+					'process.browser': true,
+					'process.env.NODE_ENV': JSON.stringify(mode)
 				},
 			}),
 			svelte({
@@ -79,8 +79,8 @@ export default {
 			replace({
 				preventAssignment: true,
 				values:{
-				  'process.browser': true,
-				  'process.env.NODE_ENV': JSON.stringify(mode)
+					'process.browser': true,
+					'process.env.NODE_ENV': JSON.stringify(mode)
 				},
 			}),
 			svelte({
@@ -102,7 +102,6 @@ export default {
 			commonjs()
 		],
 		external: Object.keys(pkg.dependencies).concat(require('module').builtinModules),
-
 		preserveEntrySignatures: 'strict',
 		onwarn,
 	},
@@ -115,14 +114,13 @@ export default {
 			replace({
 				preventAssignment: true,
 				values:{
-				  'process.browser': true,
-				  'process.env.NODE_ENV': JSON.stringify(mode)
+					'process.browser': true,
+					'process.env.NODE_ENV': JSON.stringify(mode)
 				},
 			}),
 			commonjs(),
 			!dev && terser()
 		],
-
 		preserveEntrySignatures: false,
 		onwarn,
 	}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ export default {
 		plugins: [
 			replace({
 				'process.browser': true,
+				'preventAssignment':true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -75,6 +76,7 @@ export default {
 		plugins: [
 			replace({
 				'process.browser': false,
+				'preventAssignment':true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			svelte({
@@ -108,6 +110,7 @@ export default {
 			resolve(),
 			replace({
 				'process.browser': true,
+				'preventAssignment':true,
 				'process.env.NODE_ENV': JSON.stringify(mode)
 			}),
 			commonjs(),


### PR DESCRIPTION
When starting a new sapper app with with rollup using this template you encounter a warning line 

```bash
@rollup/plugin-replace: 'preventAssignment' currently defaults to false. It is recommended to set this option to `true`, as the next major version will default this option to `true`.
```

I'm open this PR to fix it