### PR TITLE
Upgrade svelte-loader to 3.0.0

### DIFF
--- a/package_template.json
+++ b/package_template.json
@@ -42,8 +42,8 @@
     "webpack": {
       "devDependencies": {
         "file-loader": "^6.0.0",
-        "svelte-loader": "^2.9.0",
-        "webpack": "^4.7.0",
+        "svelte-loader": "^3.0.0",
+        "webpack": "^4.46.0",
         "webpack-modules": "^1.0.0"
       }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,11 @@ module.exports = {
 								dev,
 								hydratable: true
 							},
-							hotReload: dev
+							// Webpack 4 uses acorn v6 which doesn't work with HMR
+							// Use overrides from npm or resolutions from yarn to set minimal
+							// acorn version to v7+
+							// https://github.com/sveltejs/sapper-template/pull/308
+							hotReload: false
 						}
 					}
 				},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,9 +29,11 @@ module.exports = {
 					use: {
 						loader: 'svelte-loader',
 						options: {
-							dev,
-							hydratable: true,
-							hotReload: false // pending https://github.com/sveltejs/svelte/issues/2377
+							compilerOptions: {
+								dev,
+								hydratable: true
+							},
+							hotReload: dev
 						}
 					}
 				},
@@ -63,10 +65,12 @@ module.exports = {
 					use: {
 						loader: 'svelte-loader',
 						options: {
-							css: false,
-							generate: 'ssr',
-							hydratable: true,
-							dev
+							compilerOptions: {
+								css: false,
+								generate: 'ssr',
+								hydratable: true,
+								dev
+							},
 						}
 					}
 				},


### PR DESCRIPTION
I'm not sure about HMR working out of the box, because it may need Webpack HMR plugin or dev server, which I'm not sure sapper provides. :thinking: 
Will add some commits later.

Fixes #307