### PR TITLE
Handle missing sapper root element

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 import * as sapper from '@sapper/app';
 
-sapper.start({
-	target: document.querySelector('#sapper')
-});
+const target = document.querySelector('#sapper');
+if (!target) throw new Error("Missing #sapper element");
+sapper.start({ target });


### PR DESCRIPTION
Before this change, upgrading this project to typescript and enabling strict null checks would throw the following error : 

```
> @rollup/plugin-typescript TS2322: Type 'Element | null' is not assignable to type 'Node'.
  Type 'null' is not assignable to type 'Node'.

4   target: document.querySelector("#sapper"),
    ~~~~~~

  src/node_modules/@sapper/index.d.ts:20:32
    20  export function start(opts: { target: Node }): Promise<void>;
                                      ~~~~~~
    The expected type comes from property 'target' which is declared here on type '{ target: Node; }'
```