### PR TITLE
Remove non-existing error callback

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -12,6 +12,4 @@ polka() // You can also use Express
 		sirv('static', { dev }),
 		sapper.middleware()
 	)
-	.listen(PORT, err => {
-		if (err) console.log('error', err);
-	});
+	.listen(PORT);


### PR DESCRIPTION
This causes errors with TypeScript. See here: https://github.com/lukeed/polka/pull/163

EDIT: This is the end result of my investigation with this https://github.com/sveltejs/sapper-template/issues/311 This doesn't fix the TypeScript error that occurs due to polka's conflicting types with Express.