### PR TITLE
Add a note to make sure people are aware of SvelteKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 The default template for setting up a [Sapper](https://github.com/sveltejs/sapper) project. Can use either Rollup or webpack as bundler.
 
+## Please note
+
+Sapper is no longer being actively developed. You may be interested in using Sapper's succesor, [SvelteKit](https://kit.svelte.dev/) for new projects.
 
 ## Getting started
-
 
 ### Using `degit`
 


### PR DESCRIPTION
We should make sure people are at least aware of SvelteKit when starting new projects

We already have a note on https://github.com/sveltejs/template and https://sapper.svelte.dev/docs, but it still seems some people have missed it and it would probably be a good idea to mention it here as well.